### PR TITLE
feat: add global rate limiter shared across all clients

### DIFF
--- a/tests/test_global_rate_limiter.py
+++ b/tests/test_global_rate_limiter.py
@@ -88,6 +88,20 @@ class TestSteamClientRateLimiter:
         assert client.rate_limiter is custom_limiter
         assert client.rate_limiter is not get_global_rate_limiter()
 
+    def test_backward_compat_requests_per_second(self, mock_env):
+        """SteamClient should support deprecated requests_per_second param."""
+        client = SteamClient(requests_per_second=5.0)
+        # Should create a dedicated limiter, not use global
+        assert client.rate_limiter is not get_global_rate_limiter()
+        assert client.rate_limiter.requests_per_second == 5.0
+
+    def test_rate_limiter_takes_precedence_over_requests_per_second(self, mock_env):
+        """Explicit rate_limiter should take precedence over requests_per_second."""
+        custom_limiter = RateLimiter(requests_per_second=20.0)
+        client = SteamClient(rate_limiter=custom_limiter, requests_per_second=5.0)
+        assert client.rate_limiter is custom_limiter
+        assert client.rate_limiter.requests_per_second == 20.0
+
 
 class TestConcurrentAccess:
     """Tests for concurrent access to rate limiter."""


### PR DESCRIPTION
## Summary

- Implement singleton `RateLimiter` via `get_global_rate_limiter()` function
- All `SteamClient` instances share the global limiter by default, preventing rate limit violations under concurrent load
- Configurable via `STEAM_RATE_LIMIT` environment variable (default: 10 req/s)
- Backward compatible: custom rate limiters can still be passed to individual clients

## Changes

- **`steam_client.py`**: Added module-level globals and `get_global_rate_limiter()` / `reset_global_rate_limiter()` functions
- **`steam_client.py`**: Changed `SteamClient.__init__` to accept optional `rate_limiter` parameter (uses global by default)
- **`test_global_rate_limiter.py`**: New test file with comprehensive tests for singleton behavior, env var config, and concurrent access

## Testing

- [x] All 199 existing tests pass
- [x] New tests verify singleton behavior, env var configuration, and concurrent access safety

## Checklist from Issue

- [x] Single rate limiter shared across all clients
- [x] Configurable via environment variable (`STEAM_RATE_LIMIT`)
- [x] No race conditions under concurrent load (uses `asyncio.Lock`)
- [x] Unit tests for concurrent access

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)